### PR TITLE
Feature/outfit carousel and cards (review first)

### DIFF
--- a/client/components/RelatedProducts/Outfit/BlankOutfitCard.jsx
+++ b/client/components/RelatedProducts/Outfit/BlankOutfitCard.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+import Typography from '@material-ui/core/Typography';
+import products from '../../DummyData/ProductDummyData';
+import AddIcon from '@material-ui/icons/Add';
+import CardHeader from '@material-ui/core/CardHeader';
+
+
+
+
+const useStyles = makeStyles({
+  root: {
+    minWidth: 250,
+    minHeight: 300,
+    margin: 16,
+    display: 'flex',
+    backgroundColor: '#eeeeee',
+    textAlign: 'center'
+  },
+
+  plus: {
+    fontSize: 60,
+    color: 'gray',
+  }
+
+});
+const BlankOutfitCard = () => {
+  const classes = useStyles();
+  return (
+    <Card className={classes.root}>
+      <CardActionArea >
+        <CardHeader title="Add to Outfit" />
+        <CardContent >
+         <AddIcon className={classes.plus}>
+         </AddIcon>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  )
+};
+
+export default BlankOutfitCard;

--- a/client/components/RelatedProducts/Outfit/BlankOutfitCard.jsx
+++ b/client/components/RelatedProducts/Outfit/BlankOutfitCard.jsx
@@ -2,30 +2,24 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';
-import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
-import CardMedia from '@material-ui/core/CardMedia';
-import Typography from '@material-ui/core/Typography';
-import products from '../../DummyData/ProductDummyData';
 import AddIcon from '@material-ui/icons/Add';
 import CardHeader from '@material-ui/core/CardHeader';
-
-
 
 
 const useStyles = makeStyles({
   root: {
     minWidth: 250,
-    minHeight: 300,
+    minHeight: 350,
     margin: 16,
     display: 'flex',
-    backgroundColor: '#eeeeee',
+    backgroundColor: '#FEDBD0',
     textAlign: 'center'
   },
 
   plus: {
     fontSize: 60,
-    color: 'gray',
+    color: '#442C2E',
   }
 
 });

--- a/client/components/RelatedProducts/Outfit/CustomOutfitList.jsx
+++ b/client/components/RelatedProducts/Outfit/CustomOutfitList.jsx
@@ -1,9 +1,22 @@
 import React from 'react';
 import OutfitProductCard from './OutfitProductCard.jsx'
+import BlankOutfitCard from './BlankOutfitCard.jsx'
+import Carousel from 'react-elastic-carousel';
+import Typography from '@material-ui/core/Typography';
 
 const CustomOutfitList = () => {
-  return <OutfitProductCard />;
+  return (
+    <>
+      <Typography>
+        YOUR OUTFIT
+      </Typography>
+      <Carousel showEmptySlots itemsToShow={4}>
+        <BlankOutfitCard />
+        <OutfitProductCard/>
+      </Carousel>
+    </>
 
+  )
 };
 
 export default CustomOutfitList;

--- a/client/components/RelatedProducts/Outfit/OutfitProductCard.jsx
+++ b/client/components/RelatedProducts/Outfit/OutfitProductCard.jsx
@@ -1,12 +1,79 @@
 import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+import Typography from '@material-ui/core/Typography';
+import products from '../../DummyData/ProductDummyData';
+import HighlightOffIcon from '@material-ui/icons/HighlightOff';
+import Rating from '@material-ui/lab/Rating';
 
+
+const useStyles = makeStyles({
+  root: {
+    minWidth: 250,
+    minHeight: 300,
+    margin: 16
+  },
+  category: {
+    fontSize: 12,
+    textTransform: 'uppercase'
+  },
+  name: {
+    fontWeight: 700
+  },
+  price: {
+    fontSize: 12
+  },
+  media: {
+    height: 250,
+    position: 'relative'
+  },
+  icon: {
+    position: 'absolute',
+    top: '1px',
+    right: '1px',
+    color: 'black'
+  }
+});
 const OutfitProductCard = () => {
+  const classes = useStyles();
   return (
-    <Card>
-      <h1>outfit list to go here</h1>
+    <Card className={classes.root}>
+      <CardActionArea >
+      <CardMedia
+        className={classes.media}
+        image="https://images.unsplash.com/photo-1525507119028-ed4c629a60a3?ixid=MnwxMjA3fDB8MHxzZWFyY2h8M3x8Y2xvdGhpbmd8ZW58MHx8MHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60"
+        />
+        <HighlightOffIcon className={classes.icon}>
+        </HighlightOffIcon>
+        <CardContent>
+          {/*
+          sale_price if on sale
+          */}
+          <Typography className={classes.category}>
+            {/* {props.relatedWithNameCatPrice.category} */}
+          </Typography>
+          <Typography className={classes.name}>
+            {/* {props.relatedWithNameCatPrice.name} */}
+          </Typography>
+          <Typography className={classes.price}>
+            {/* {props.relatedWithNameCatPrice.default_price} */}
+          </Typography>
+          <Typography>
+            <Rating
+              name="rating"
+              defaultValue={3.5}
+              precision={0.25}
+              size="small"
+          ></Rating>
+          </Typography>
+        </CardContent>
+      </CardActionArea>
     </Card>
-  );
+  )
 };
 
 export default OutfitProductCard;

--- a/client/components/RelatedProducts/Outfit/OutfitProductCard.jsx
+++ b/client/components/RelatedProducts/Outfit/OutfitProductCard.jsx
@@ -6,7 +6,6 @@ import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import CardMedia from '@material-ui/core/CardMedia';
 import Typography from '@material-ui/core/Typography';
-import products from '../../DummyData/ProductDummyData';
 import HighlightOffIcon from '@material-ui/icons/HighlightOff';
 import Rating from '@material-ui/lab/Rating';
 
@@ -14,7 +13,8 @@ import Rating from '@material-ui/lab/Rating';
 const useStyles = makeStyles({
   root: {
     minWidth: 250,
-    minHeight: 300,
+    minHeight: 350,
+    maxHeight: 350,
     margin: 16
   },
   category: {
@@ -33,9 +33,9 @@ const useStyles = makeStyles({
   },
   icon: {
     position: 'absolute',
-    top: '1px',
-    right: '1px',
-    color: 'black'
+    top: '5px',
+    right: '5px',
+    color: '#442C2E'
   }
 });
 const OutfitProductCard = () => {

--- a/client/components/RelatedProducts/Related/RelatedProductCard.jsx
+++ b/client/components/RelatedProducts/Related/RelatedProductCard.jsx
@@ -14,7 +14,8 @@ import Rating from '@material-ui/lab/Rating';
 const useStyles = makeStyles({
   root: {
     minWidth: 250,
-    minHeight: 300,
+    minHeight: 350,
+    maxHeight: 350,
     margin: 16
   },
   category: {
@@ -33,8 +34,8 @@ const useStyles = makeStyles({
   },
   overlay: {
     position: 'absolute',
-    top: '1px',
-    right: '1px',
+    top: '5px',
+    right: '5px',
     color: '#ffb400'
   }
 });


### PR DESCRIPTION
@julia-thea @ChrisRPeterson @dylanreid7 

--Created an outfit carousel similar to the related products carousel
--Created a BlankOutfitCard, which will always appear in the first, lefthand position (will eventually act as a button to add to list)
--Subsequent cards will be OutfitProductCards which will be added when the user clicks the BlankOutfitCard (currently just a placeholder card for now)
