### PR TITLE
Feature/card sale price

### DIFF
--- a/client/components/RelatedProducts/Outfit/BlankOutfitCard.jsx
+++ b/client/components/RelatedProducts/Outfit/BlankOutfitCard.jsx
@@ -10,13 +10,12 @@ import CardHeader from '@material-ui/core/CardHeader';
 const useStyles = makeStyles({
   root: {
     minWidth: 250,
-    minHeight: 350,
+    minHeight: 375,
     margin: 16,
     display: 'flex',
     backgroundColor: '#FEDBD0',
     textAlign: 'center'
   },
-
   plus: {
     fontSize: 60,
     color: '#442C2E',

--- a/client/components/RelatedProducts/Outfit/OutfitProductCard.jsx
+++ b/client/components/RelatedProducts/Outfit/OutfitProductCard.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';
-import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import CardMedia from '@material-ui/core/CardMedia';
 import Typography from '@material-ui/core/Typography';
@@ -10,6 +9,7 @@ import HighlightOffIcon from '@material-ui/icons/HighlightOff';
 import Rating from '@material-ui/lab/Rating';
 import { withStyles } from '@material-ui/core/styles';
 import { StarBorder, Star } from '@material-ui/icons';
+import { red } from '@material-ui/core/colors';
 
 const StyledRating = withStyles({
   iconFilled: {
@@ -23,19 +23,15 @@ const StyledRating = withStyles({
 const useStyles = makeStyles({
   root: {
     minWidth: 250,
-    minHeight: 350,
-    maxHeight: 350,
+    minHeight: 375,
+    maxHeight: 375,
     margin: 16
   },
   category: {
-    fontSize: 12,
     textTransform: 'uppercase'
   },
   name: {
     fontWeight: 700
-  },
-  price: {
-    fontSize: 12
   },
   media: {
     height: 250,
@@ -46,10 +42,17 @@ const useStyles = makeStyles({
     top: '5px',
     right: '5px',
     color: '#442C2E'
+  },
+  sale: {
+    marginLeft: '5px',
+    color: red[400],
+  },
+  strikethrough: {
+    textDecoration: 'line-through',
   }
 });
+
 const OutfitProductCard = ({ outfitCardData }) => {
-  console.log({outfitCardData})
   const classes = useStyles();
   return (
     <Card className={classes.root}>
@@ -61,22 +64,24 @@ const OutfitProductCard = ({ outfitCardData }) => {
         <HighlightOffIcon className={classes.icon}>
         </HighlightOffIcon>
         <CardContent>
-          <Typography className={classes.category}>
+          <Typography className={classes.category} variant="caption">
             {outfitCardData.category}
           </Typography>
           <Typography className={classes.name}>
             {outfitCardData.name}
           </Typography>
           {outfitCardData.sale_price ? (
-            <Typography className={classes.sale}>
-              {`$${outfitCardData.sale_price}`}
-              <Typography className={classes.price}>
-              {`$${outfitCardData.original_price}`}
+            <>
+              <Typography className={classes.strikethrough} variant="caption">
+                ${Math.round(outfitCardData.original_price)}
               </Typography>
-            </Typography>
+              <Typography className={classes.sale} variant="caption">
+                ${Math.round(outfitCardData.sale_price)}
+              </Typography>
+            </>
           ) : (
-            <Typography className={classes.price}>
-            {`$${outfitCardData.original_price}`}
+            <Typography variant="caption">
+            ${Math.round(outfitCardData.original_price)}
             </Typography>
           )}
           <Typography>

--- a/client/components/RelatedProducts/Outfit/OutfitProductCard.jsx
+++ b/client/components/RelatedProducts/Outfit/OutfitProductCard.jsx
@@ -49,6 +49,7 @@ const useStyles = makeStyles({
   }
 });
 const OutfitProductCard = ({ outfitCardData }) => {
+  console.log({outfitCardData})
   const classes = useStyles();
   return (
     <Card className={classes.root}>
@@ -60,18 +61,24 @@ const OutfitProductCard = ({ outfitCardData }) => {
         <HighlightOffIcon className={classes.icon}>
         </HighlightOffIcon>
         <CardContent>
-          {/*
-          sale_price if on sale
-          */}
           <Typography className={classes.category}>
             {outfitCardData.category}
           </Typography>
           <Typography className={classes.name}>
             {outfitCardData.name}
           </Typography>
-          <Typography className={classes.price}>
+          {outfitCardData.sale_price ? (
+            <Typography className={classes.sale}>
+              {`$${outfitCardData.sale_price}`}
+              <Typography className={classes.price}>
+              {`$${outfitCardData.original_price}`}
+              </Typography>
+            </Typography>
+          ) : (
+            <Typography className={classes.price}>
             {`$${outfitCardData.original_price}`}
-          </Typography>
+            </Typography>
+          )}
           <Typography>
             <StyledRating
               emptyIcon={<StarBorder fontSize="inherit" />}

--- a/client/components/RelatedProducts/Related/RelatedProductCard.jsx
+++ b/client/components/RelatedProducts/Related/RelatedProductCard.jsx
@@ -8,24 +8,20 @@ import CardMedia from '@material-ui/core/CardMedia';
 import Typography from '@material-ui/core/Typography';
 import Icon from '@material-ui/core/Icon';
 import Rating from '@material-ui/lab/Rating';
-
+import { red } from '@material-ui/core/colors';
 
 const useStyles = makeStyles({
   root: {
     minWidth: 250,
-    minHeight: 350,
-    maxHeight: 350,
+    minHeight: 375,
+    maxHeight: 375,
     margin: 16
   },
   category: {
-    fontSize: 12,
     textTransform: 'uppercase'
   },
   name: {
     fontWeight: 700
-  },
-  price: {
-    fontSize: 12
   },
   media: {
     height: 250,
@@ -36,6 +32,13 @@ const useStyles = makeStyles({
     top: '5px',
     right: '5px',
     color: '#ffb400'
+  },
+  sale: {
+    marginLeft: '5px',
+    color: red[400],
+  },
+  strikethrough: {
+    textDecoration: 'line-through',
   }
 });
 
@@ -64,22 +67,24 @@ const RelatedProductCard = ({relatedProductData}) => {
           <span className="material-icons">star_rate</span>
         </Icon>
         <CardContent>
-          <Typography className={classes.category}>
+          <Typography className={classes.category} variant="caption">
             {relatedProductData.category}
           </Typography>
           <Typography className={classes.name}>
             {relatedProductData.name}
           </Typography>
           {salePrice ? (
-            <Typography className={classes.sale}>
-              {`$${salePrice}`}
-              <Typography className={classes.price}>
-              {`$${relatedProductData.default_price}`}
+            <>
+              <Typography className={classes.strikethrough} variant="caption">
+                ${Math.round(relatedProductData.default_price)}
               </Typography>
-            </Typography>
+              <Typography className={classes.sale} variant="caption">
+                ${Math.round(salePrice)}
+              </Typography>
+            </>
           ) : (
-            <Typography className={classes.price}>
-            {`$${relatedProductData.default_price}`}
+            <Typography variant="caption">
+            ${Math.round(relatedProductData.default_price)}
             </Typography>
           )}
           <Typography>

--- a/client/components/RelatedProducts/Related/RelatedProductCard.jsx
+++ b/client/components/RelatedProducts/Related/RelatedProductCard.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';
-import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import CardMedia from '@material-ui/core/CardMedia';
 import Typography from '@material-ui/core/Typography';
@@ -41,9 +40,16 @@ const useStyles = makeStyles({
 });
 
 
-const RelatedProductCard = ({relatedProductsData}) => {
+const RelatedProductCard = ({relatedProductData}) => {
   const classes = useStyles();
-  const image = relatedProductsData.results[0].photos[0].url;
+  const image = relatedProductData.results[0].photos[0].url;
+
+  let salePrice = null;
+  for (let style of relatedProductData.results) {
+    if (style['default?'] === true) {
+      salePrice = style['sale_price'];
+    }
+  }
 
   return (
     <Card className={classes.root}>
@@ -58,18 +64,24 @@ const RelatedProductCard = ({relatedProductsData}) => {
           <span className="material-icons">star_rate</span>
         </Icon>
         <CardContent>
-          {/*
-          sale_price if on sale
-          */}
           <Typography className={classes.category}>
-            {relatedProductsData.category}
+            {relatedProductData.category}
           </Typography>
           <Typography className={classes.name}>
-            {relatedProductsData.name}
+            {relatedProductData.name}
           </Typography>
-          <Typography className={classes.price}>
-            {relatedProductsData.default_price}
-          </Typography>
+          {salePrice ? (
+            <Typography className={classes.sale}>
+              {`$${salePrice}`}
+              <Typography className={classes.price}>
+              {`$${relatedProductData.default_price}`}
+              </Typography>
+            </Typography>
+          ) : (
+            <Typography className={classes.price}>
+            {`$${relatedProductData.default_price}`}
+            </Typography>
+          )}
           <Typography>
             <Rating
               name="rating"

--- a/client/components/RelatedProducts/Related/RelatedProductsList.jsx
+++ b/client/components/RelatedProducts/Related/RelatedProductsList.jsx
@@ -16,7 +16,7 @@ const RelatedProductsList = ({relatedProductsData}) => {
         RELATED PRODUCTS
       </Typography>
       <Carousel showEmptySlots itemsToShow={4}>
-          {relatedProductsData.map(item => <RelatedProductCard key={item.id} relatedProductsData={item}/>)}
+          {relatedProductsData.map(item => <RelatedProductCard key={item.id} relatedProductData={item}/>)}
       </Carousel>
     </>
   )

--- a/client/components/RelatedProducts/RelatedProducts.jsx
+++ b/client/components/RelatedProducts/RelatedProducts.jsx
@@ -81,6 +81,7 @@ const RelatedProducts = ({
   return (
     <div id='related'>
       <Grid container spacing={2}>
+        {console.log({relatedProductsData})}
         <RelatedProductsList relatedProductsData={relatedProductsData} />
       </Grid>
       <Grid>

--- a/client/components/RelatedProducts/RelatedProducts.jsx
+++ b/client/components/RelatedProducts/RelatedProducts.jsx
@@ -81,7 +81,6 @@ const RelatedProducts = ({
   return (
     <div id='related'>
       <Grid container spacing={2}>
-        {console.log({relatedProductsData})}
         <RelatedProductsList relatedProductsData={relatedProductsData} />
       </Grid>
       <Grid>


### PR DESCRIPTION
@julia-thea @ChrisRPeterson @dylanreid7 

I added the sale price when available/original price with a strikethrough to both the OutfitProductCard and RelatedProductCard.  
 --Styled to match the same format as in ProductOverview

Per the spec: "As the price is not actually derived from the product, the price displayed should be that for the default style."
-- NOTE: For the RelatedProductCard, I checked to see if the default style had a sale, and if so would display it.   HOWEVER, I tested lots of different product Ids and NONE of them seemed to have a sale price for the default style.  I went ahead and included the sale price formatting for the RelatedProductCards for completeness, but don't be surprised if there is no sale price ever showing up within that list.