### PR TITLE
Feature: Click RelatedProductCard and it will change the current product to that one

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -93,7 +93,7 @@ const getProductStyles = (id) => {
 };
 
 const App = () => {
-  const [productId] = useState(24156);
+  const [productId, setProductId] = useState(24156);
   const [product, setProduct] = useState([]);
   const [currentStyle, setCurrentStyle] = useState({});
   const [styles, setStyles] = useState([]);
@@ -111,6 +111,7 @@ const App = () => {
   useEffect(() => {
     async function fetchProduct() {
       const result = await getProduct(productId);
+      console.log({productId})
       setProduct(result);
     }
 
@@ -127,7 +128,8 @@ const App = () => {
 
     fetchProduct();
     setupStyles();
-  }, []);
+  }, [productId]);
+
 
   return (
     <ThemeProvider theme={theme}>
@@ -156,6 +158,7 @@ const App = () => {
                 product={product}
                 currentStyle={currentStyle}
                 averageRating={averageRating}
+                setProductId={setProductId}
               />
             </Grid>
             <Grid item xs={12}>

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -111,7 +111,6 @@ const App = () => {
   useEffect(() => {
     async function fetchProduct() {
       const result = await getProduct(productId);
-      console.log({productId})
       setProduct(result);
     }
 

--- a/client/components/QuestionsAndAnswers/QuestionsAndAnswers.jsx
+++ b/client/components/QuestionsAndAnswers/QuestionsAndAnswers.jsx
@@ -34,7 +34,7 @@ const QuestionsAndAnswers = ( { productId }) => {
       setShownQuestions(sortQuestionsByHelpfulness(questionData.results, 2));
     }
     fetchQuestions();
-  }, []);
+  }, [productId]);
 
   const handleMoreQuestionsClick = () => {
     var numQuestionsToShow;

--- a/client/components/RelatedProducts/Related/RelatedProductCard.jsx
+++ b/client/components/RelatedProducts/Related/RelatedProductCard.jsx
@@ -73,7 +73,7 @@ const RelatedProductCard = ({
       salePrice = style['sale_price'];
     }
   }
-  console.log({relatedProductData})
+
   //Click handlers for Comparison Modal
   const [open, setOpen] = useState(false);
 
@@ -88,7 +88,6 @@ const RelatedProductCard = ({
   //Click handler for changing current product in overview
   const handleRelatedCardClick = () => {
     setProductId(relatedProductData.id)
-    console.log('related id:', relatedProductData.id)
   }
 
   //reused same logic from App.js for calculating ratings average:

--- a/client/components/RelatedProducts/Related/RelatedProductCard.jsx
+++ b/client/components/RelatedProducts/Related/RelatedProductCard.jsx
@@ -60,7 +60,8 @@ const useStyles = makeStyles({
 
 const RelatedProductCard = ({
   relatedProductData,
-  product
+  product,
+  setProductId
 }) => {
   const classes = useStyles();
 
@@ -72,7 +73,7 @@ const RelatedProductCard = ({
       salePrice = style['sale_price'];
     }
   }
-
+  console.log({relatedProductData})
   //Click handlers for Comparison Modal
   const [open, setOpen] = useState(false);
 
@@ -82,6 +83,12 @@ const RelatedProductCard = ({
 
   const handleClose = () => {
     setOpen(false)
+  }
+
+  //Click handler for changing current product in overview
+  const handleRelatedCardClick = () => {
+    setProductId(relatedProductData.id)
+    console.log('related id:', relatedProductData.id)
   }
 
   //reused same logic from App.js for calculating ratings average:
@@ -97,7 +104,7 @@ const RelatedProductCard = ({
   let ratingAverage = (sumOfRatings / numberOfRatings) || 0;
 
   return (
-    <Card className={classes.root}>
+    <Card onClick={handleRelatedCardClick} className={classes.root}>
       <CardActionArea >
         <CardMedia
         className={classes.media}

--- a/client/components/RelatedProducts/Related/RelatedProductsList.jsx
+++ b/client/components/RelatedProducts/Related/RelatedProductsList.jsx
@@ -10,7 +10,8 @@ import Typography from '@material-ui/core/Typography';
 
 const RelatedProductsList = ({
   relatedProductsData,
-  product
+  product,
+  setProductId
 }) => {
 
   return  (
@@ -19,7 +20,7 @@ const RelatedProductsList = ({
         RELATED PRODUCTS
       </Typography>
       <Carousel showEmptySlots itemsToShow={4}>
-          {relatedProductsData.map(item => <RelatedProductCard key={item.id} relatedProductData={item} product={product} />)}
+          {relatedProductsData.map(item => <RelatedProductCard key={item.id} relatedProductData={item} product={product} setProductId={setProductId}/>)}
       </Carousel>
     </>
   )

--- a/client/components/RelatedProducts/RelatedProducts.jsx
+++ b/client/components/RelatedProducts/RelatedProducts.jsx
@@ -11,7 +11,8 @@ const RelatedProducts = ({
   productId,
   product,
   currentStyle,
-  averageRating
+  averageRating,
+  setProductId
 }) => {
 
   const [relatedProductsData, setRelatedProductsData] = useState([]);
@@ -98,7 +99,7 @@ const RelatedProducts = ({
   return (
     <div id='related'>
       <Grid container spacing={2}>
-        <RelatedProductsList relatedProductsData={relatedProductsData} product={product} />
+        <RelatedProductsList setProductId={setProductId} relatedProductsData={relatedProductsData} product={product} />
       </Grid>
       <Grid>
         <CustomOutfitList outfitCardsData={outfitCardsData} addToOutfit={addToOutfit} removeCard={removeCard} />

--- a/client/components/RelatedProducts/RelatedProducts.jsx
+++ b/client/components/RelatedProducts/RelatedProducts.jsx
@@ -27,16 +27,18 @@ const RelatedProducts = ({
   useEffect(() => {
     getRelatedIds(productId)
     .then(relatedIdsResult => {
+      const uniqueRelatedIdsSet = new Set(relatedIdsResult);
+      const uniqueRelatedIds = [...uniqueRelatedIdsSet]
 
-      const productsIdGetReq = relatedIdsResult.map(id => {
+      const productsIdGetReq = uniqueRelatedIds.map(id => {
         return axios.get(`https://app-hrsei-api.herokuapp.com/api/fec2/hratx/products/${id}`);
       })
 
-      const stylesGetReq = relatedIdsResult.map(id => {
+      const stylesGetReq = uniqueRelatedIds.map(id => {
         return axios.get(`https://app-hrsei-api.herokuapp.com/api/fec2/hratx/products/${id}/styles`);
       })
 
-      const ratingsGetReq = relatedIdsResult.map(id => {
+      const ratingsGetReq = uniqueRelatedIds.map(id => {
         return axios.get(`https://app-hrsei-api.herokuapp.com/api/fec2/hratx/reviews/meta?product_id=${id}`);
       })
 


### PR DESCRIPTION
@julia-thea @ChrisRPeterson @dylanreid7 

For RelatedProductCard: "The card itself will be clickable. Clicking the card will navigate to the detail page for that product."

--@dylanreid7:  I noticed your Q&A section was not changing based on productId change, so I added [productId] instead of [] to line 37 of QuestionsAndAnswers.jsx.  
--I noticed the data for Heir Force Ones was incorrect: info from API was not as expected - received duplicate related products (24161 twice): [
    24161,
    24161,
    24163,
    24164,
    24156,
    24158
]
  -Updated relatedIdsResult in RelatedProducts section to uniqueRelatedIds to avoid warnings of duplicate keys and avoid duplicate relatedProductCards showing up in the RelatedProductList
