### PR TITLE
Fixed bug related to comparison modal and changing the current product

### DIFF
--- a/client/components/RelatedProducts/Related/RelatedProductCard.jsx
+++ b/client/components/RelatedProducts/Related/RelatedProductCard.jsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import ComparisonModal from '../ComparisonModal.jsx'
 import { makeStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
 import CardActionArea from '@material-ui/core/CardActionArea';
 import CardContent from '@material-ui/core/CardContent';
 import CardMedia from '@material-ui/core/CardMedia';
@@ -77,14 +78,19 @@ const RelatedProductCard = ({
   //Click handlers for Comparison Modal
   const [open, setOpen] = useState(false);
 
-  const handleOpen = () => {
-    setOpen(true)
+  const handleOpen = (e) => {
+    e.stopPropagation();
+    setOpen(true);
   }
 
-  const handleClose = () => {
-    setOpen(false)
+  const handleClose = (e) => {
+    e.stopPropagation();
+    setOpen(false);
   }
 
+  const handleDialogClick = (e) => {
+    e.stopPropagation();
+  }
   //Click handler for changing current product in overview
   const handleRelatedCardClick = () => {
     setProductId(relatedProductData.id)
@@ -111,17 +117,21 @@ const RelatedProductCard = ({
         image={image}
         alt="Image not available"
         />
-        <SvgIcon onClick={handleOpen} className={classes.overlay}>
-          <path
-          d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z">
-          </path>
-        </SvgIcon>
-        <Dialog
-          open={open}
-          onClose={handleClose}
-        >
-          <ComparisonModal  relatedProductData={relatedProductData} product={product} />
-        </Dialog>
+        <CardActions >
+          <SvgIcon onClick={(e) => handleOpen(e)} className={classes.overlay}>
+            <path
+            d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z">
+            </path>
+          </SvgIcon>
+        </CardActions>
+            <Dialog
+              open={open}
+              onClick={handleDialogClick}
+              onClose={(e) => handleClose(e)}
+            >
+              <ComparisonModal  relatedProductData={relatedProductData} product={product} />
+            </Dialog>
+
         <CardContent>
           <Typography className={classes.category} variant="caption">
             {relatedProductData.category}


### PR DESCRIPTION
@julia-thea @ChrisRPeterson @dylanreid7 

Bug fix for RelatedProductCard: when the star icon was clicked, it opened the comparison modal, but it also changed the current product.  The event was bubbling up to the parent.

--Added e.stopPropagation() to Icon click handlers
--Fix also required a new click handler to be placed on Dialog itself with e.preventPropagation() as well