### PR TITLE
Disables selecting out of stock sizes

### DIFF
--- a/client/components/ProductOverview/AddToCart.jsx
+++ b/client/components/ProductOverview/AddToCart.jsx
@@ -73,6 +73,10 @@ const AddToCart = ({ currentStyle }) => {
       </Grid>
       <Grid item xs={12}>
         {skus.map((sku, idx) => {
+          let isOutOfStock = false;
+          if (sku.quantity === 0) {
+            isOutOfStock = true;
+          }
           return sku.size === selectedSize ? (
             <Button
               key={idx}
@@ -93,6 +97,7 @@ const AddToCart = ({ currentStyle }) => {
               variant="text"
               color="secondary"
               size="small"
+              disabled={isOutOfStock}
               onClick={() => {
                 handleSizeClick(sku.size);
               }}


### PR DESCRIPTION
Disables the button for sizes that are out of stock

I used react dev tools to manually set a size to be out of stock to test this. I don't know if any sizes are actually out of stock.