### PR TITLE
Feature/outfit local storage

### DIFF
--- a/client/components/RelatedProducts/RelatedProducts.jsx
+++ b/client/components/RelatedProducts/RelatedProducts.jsx
@@ -16,7 +16,6 @@ const RelatedProducts = ({
 }) => {
 
   const [relatedProductsData, setRelatedProductsData] = useState([]);
-  const [outfitStylesList, setOutfitStylesList] = useState([]);
   const [outfitCardsData, setOutfitCardsData] = useState([]);
 
   async function getRelatedIds(productId) {
@@ -64,11 +63,15 @@ const RelatedProducts = ({
   }, [productId]);
 
   const addToOutfit = () => {
-    if (!outfitStylesList.includes(currentStyle.style_id)) {
-      const outfitStylesListCopy = outfitStylesList.slice();
-      outfitStylesListCopy.push(currentStyle.style_id);
-      setOutfitStylesList(outfitStylesListCopy);
+    let isPresentInOutfit = false;
+    for (let outfit of outfitCardsData) {
+      if (outfit.style_id === currentStyle.style_id) {
+        isPresentInOutfit = true;
+        break;
+      }
+    }
 
+    if (!isPresentInOutfit) {
       const outfitCardsDataCopy = outfitCardsData.slice();
       const outfitCardData = {
         name: currentStyle.name,
@@ -87,11 +90,13 @@ const RelatedProducts = ({
   }
 
   const removeCard = (styleId) => {
-    let indexOfCardToRemove = outfitStylesList.indexOf(styleId);
-
-    outfitStylesList.splice(indexOfCardToRemove, 1);
-    let removedOutfitStylesList = outfitStylesList.slice();
-    setOutfitStylesList(removedOutfitStylesList);
+    let indexOfCardToRemove;
+    for (let i = 0; i < outfitCardsData.length; i++) {
+      if (outfitCardsData[i].style_id === styleId) {
+        indexOfCardToRemove = i;
+        break;
+      }
+    }
 
     outfitCardsData.splice(indexOfCardToRemove, 1);
     let removedOutfitCardsData = outfitCardsData.slice();

--- a/client/components/RelatedProducts/RelatedProducts.jsx
+++ b/client/components/RelatedProducts/RelatedProducts.jsx
@@ -16,7 +16,7 @@ const RelatedProducts = ({
 }) => {
 
   const [relatedProductsData, setRelatedProductsData] = useState([]);
-  const [outfitCardsData, setOutfitCardsData] = useState([]);
+  const [outfitCardsData, setOutfitCardsData] = useState(JSON.parse(localStorage.getItem('outfitCardsData')) || []);
 
   async function getRelatedIds(productId) {
     const relatedIdsResponse = await axios.get(`https://app-hrsei-api.herokuapp.com/api/fec2/hratx/products/${productId}/related`);
@@ -82,8 +82,9 @@ const RelatedProducts = ({
         category: product.category,
         rating: averageRating
       }
-      outfitCardsDataCopy.push(outfitCardData)
-      setOutfitCardsData(outfitCardsDataCopy)
+      outfitCardsDataCopy.push(outfitCardData);
+      setOutfitCardsData(outfitCardsDataCopy);
+      localStorage.setItem('outfitCardsData', JSON.stringify(outfitCardsDataCopy));
     } else {
       alert('This style has already been added to your outfit list!')
     }
@@ -101,6 +102,7 @@ const RelatedProducts = ({
     outfitCardsData.splice(indexOfCardToRemove, 1);
     let removedOutfitCardsData = outfitCardsData.slice();
     setOutfitCardsData(removedOutfitCardsData);
+    localStorage.setItem('outfitCardsData', JSON.stringify(removedOutfitCardsData));
   }
 
   return (


### PR DESCRIPTION
@julia-thea @ChrisRPeterson @dylanreid7 

Each customer will have one outfit list.  This list will be the same regardless of which product detail page they are viewing.  Therefore, the list items should persist across page navigation.
The list should persist for each customer even if they exit the website and return at a later time.

- First had to refactor state management for OutfitProductList:
  -- Was previously storing the outfit objects in the outfitCardsData array, and the style_ids of the outfits within a separate array in state.
  -- Refactored to remove the unnecessary separate style_ids array and use the outfitCardsData array alone
- Stored the outfitCardsData in local storage to persist even when the page is refreshed or website is exited.
  
