### PR TITLE
Styled carousel arrows and removed pagination dot

### DIFF
--- a/client/components/RelatedProducts/Related/RelatedProductsList.jsx
+++ b/client/components/RelatedProducts/Related/RelatedProductsList.jsx
@@ -3,16 +3,13 @@ import RelatedProductCard from './RelatedProductCard.jsx';
 import Carousel from 'react-elastic-carousel';
 import Typography from '@material-ui/core/Typography';
 
-//CSS styling for later so disabled arrow does not show:
-// .rec.rec-arrow:disabled {
-//   visibility: hidden;
-// }
 
 const RelatedProductsList = ({
   relatedProductsData,
   product,
   setProductId
 }) => {
+
 
   return  (
     <>

--- a/client/stylesheets/index.scss
+++ b/client/stylesheets/index.scss
@@ -16,3 +16,7 @@
  visibility: hidden;
 }
 
+.rec.carousel {
+  cursor: pointer
+}
+

--- a/client/stylesheets/index.scss
+++ b/client/stylesheets/index.scss
@@ -1,0 +1,18 @@
+//RelatedProductList and CustomOutfitList Carousel styling:
+.rec.rec-arrow:disabled {
+  visibility: hidden;
+}
+
+.rec.rec-arrow {
+  color: #442c2e !important;
+  background-color: #FEDBD0 !important;
+}
+
+.rec.rec-arrow:hover {
+  background-color: #442c2e !important;
+  color: #FEDBD0 !important;
+}
+.rec.rec-dot {
+ visibility: hidden;
+}
+


### PR DESCRIPTION
@julia-thea @ChrisRPeterson @dylanreid7 
Carousels for relatedProductList and CustomOutfitList:
--When the first card is all the way on the left of the screen, the left arrow should be hidden. Similarly, when the last card appears on the far right of the list, the right arrow will be hidden.
-- Removed pagination dot
--Styled arrows with theme colors
--Was **unable** to get the arrows to sit on top of the first and last cards as it looks in the spec diagram though.  Open to suggestions or if you think they can be left off to the sides as is.