### PR TITLE
Added some placeholder links to the header

### DIFF
--- a/client/components/Header.jsx
+++ b/client/components/Header.jsx
@@ -8,8 +8,8 @@ const Header = () => {
   return (
     <>
       <Box
-        marginLeft="250px"
-        marginRight="250px"
+        marginLeft="14%"
+        marginRight="14%"
         display="flex"
         flexGrow={1}
         justifyContent="space-around"

--- a/client/components/Header.jsx
+++ b/client/components/Header.jsx
@@ -1,24 +1,29 @@
 import React from 'react';
 
 import Typography from '@material-ui/core/Typography';
-import StarBorderIcon from '@material-ui/icons/StarBorder';
 import ShoppingCartIcon from '@material-ui/icons/ShoppingCart';
-import SearchIcon from '@material-ui/icons/Search';
-import { Box, Container } from '@material-ui/core';
+import { Box } from '@material-ui/core';
 
 const Header = () => {
   return (
     <>
-      <Box display="flex" flexGrow={1}>
-        <Typography variant="h4">
-          <StarBorderIcon fontSize="inherit" />
-          {'   '}
-          J. CAD
-        </Typography>
+      <Box
+        marginLeft="250px"
+        marginRight="250px"
+        display="flex"
+        flexGrow={1}
+        justifyContent="space-around"
+        alignItems="center"
+      >
+        <Typography variant="h4">J. CAD</Typography>
+        <Typography variant="button">New</Typography>
+        <Typography variant="button">Women</Typography>
+        <Typography variant="button">Men</Typography>
+        <Typography variant="button">Clearance</Typography>
+        <Typography variant="button">Sustainability</Typography>
+        <Typography variant="button">My Account</Typography>
+        <ShoppingCartIcon />
       </Box>
-      <Typography variant="button">My Account</Typography>
-      <SearchIcon />
-      <ShoppingCartIcon />
     </>
   );
 };


### PR DESCRIPTION
-Added extra text to the app bar


The margins on the app bar are set with percentages, so I'm not expecting this to work on all screen sizes. I'm on a 1920x1080p monitor so, it probably really only works for that screen size. If we don't come up with a better solution then we will have to make sure this is tweaked to match whoever screen shares during the demo.