### PR TITLE
Fix wrong product answers bug

### DIFF
--- a/client/components/QuestionsAndAnswers/QAndAComponents/AddQuestion.jsx
+++ b/client/components/QuestionsAndAnswers/QAndAComponents/AddQuestion.jsx
@@ -109,5 +109,4 @@ const AddQuestion = ({ product, productId }) => {
   )
 }
 
-
 export default AddQuestion;

--- a/client/components/QuestionsAndAnswers/QAndAComponents/AddQuestion.jsx
+++ b/client/components/QuestionsAndAnswers/QAndAComponents/AddQuestion.jsx
@@ -106,4 +106,5 @@ const AddQuestion = ({ product, productId }) => {
   )
 }
 
+
 export default AddQuestion;

--- a/client/components/QuestionsAndAnswers/QAndAComponents/Helpful.jsx
+++ b/client/components/QuestionsAndAnswers/QAndAComponents/Helpful.jsx
@@ -11,7 +11,6 @@ const useStyles = makeStyles((theme) => ({
 
 const Helpful = ({ helpfulness, questionId, answerId }) => {
   const classes = useStyles();
-  const [helpful, setHelpful] = useState(helpfulness);
   const [clicked, setClicked] = useState(false);
 
   const handleClick = () => {
@@ -21,7 +20,6 @@ const Helpful = ({ helpfulness, questionId, answerId }) => {
     if (questionId === 'NA') {
       axios.put(`https://app-hrsei-api.herokuapp.com/api/fec2/hratx/qa/answers/${answerId}/helpful`)
         .then((results) => {
-          setHelpful(helpfulness + 1);
           setClicked(true);
         })
         .catch((err) => {
@@ -30,21 +28,22 @@ const Helpful = ({ helpfulness, questionId, answerId }) => {
     } else if (answerId === 'NA') {
       axios.put(`https://app-hrsei-api.herokuapp.com/api/fec2/hratx/qa/questions/${questionId}/helpful`)
         .then((results) => {
-          setHelpful(helpfulness + 1);
           setClicked(true);
         })
         .catch((err) => {
           console.error(err);
         })
     }
-
   }
 
   return (
     <div>
       <Typography variant="caption">Helpful?   </Typography>
       <Typography variant="caption" onClick={handleClick} className={classes.yes}>Yes</Typography>
-      <Typography variant="caption">  ({helpful})</Typography>
+      {clicked ?
+        <Typography variant="caption">  ({helpfulness + 1})</Typography> :
+        <Typography variant="caption">  ({helpfulness})</Typography>
+      }
     </div>
   );
 };

--- a/client/components/QuestionsAndAnswers/QAndAComponents/QAndA.jsx
+++ b/client/components/QuestionsAndAnswers/QAndAComponents/QAndA.jsx
@@ -35,20 +35,18 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const QAndA = ({ question, product }) => {
-  const allSortedAnswers = createSortedAnswers(question.answers, question.answers.length)
-  const twoSortedAnswers = createSortedAnswers(question.answers, 2);
-  const [shownAnswers, setShownAnswers] = useState(twoSortedAnswers);
+  var allSortedAnswers = createSortedAnswers(question.answers, question.answers.length)
+  var twoSortedAnswers = createSortedAnswers(question.answers, 2);
   const [isCollapsed, setIsCollapsed] = useState(true);
 
   const handleMoreAnswersClick = () => {
-    setShownAnswers(allSortedAnswers);
     setIsCollapsed(false);
   }
 
   const handleCollapseClick = () => {
-    setShownAnswers(twoSortedAnswers);
     setIsCollapsed(true);
   }
+
 
   const classes = useStyles();
   return (
@@ -76,12 +74,16 @@ const QAndA = ({ question, product }) => {
         </Grid>
       </Grid>
       <Grid>
-        {shownAnswers.map((answer, i) => {
-          return <Answer answer={answer} key={i}/>
-        })}
+        {isCollapsed ?
+          twoSortedAnswers.map((answer, i) => {
+            return <Answer answer={answer} key={i}/>
+          }) :
+          allSortedAnswers.map((answer, i) => {
+            return <Answer answer={answer} key={i}/>
+          })}
       </Grid>
       <Grid>
-        {allSortedAnswers.length > shownAnswers.length && isCollapsed
+        {allSortedAnswers.length > 2 && isCollapsed
         ?
         <Typography variant="caption" onClick={handleMoreAnswersClick} className={classes.cursor}>SEE MORE ANSWERS</Typography>
         :

--- a/client/components/QuestionsAndAnswers/QAndAComponents/QAndA.jsx
+++ b/client/components/QuestionsAndAnswers/QAndAComponents/QAndA.jsx
@@ -47,7 +47,6 @@ const QAndA = ({ question, product }) => {
     setIsCollapsed(true);
   }
 
-
   const classes = useStyles();
   return (
     <>


### PR DESCRIPTION
@julia-thea @ChrisRPeterson @acdavitt 
-  This pull request is to fix a bug that was occurring.  When a user would change the current product, the questions would update, but the answers and helpfulness would not.
- The main changes are that two answer variables (lines 38 and 39 of QandA) were changed from const to var.  Also, two variables (shownAnswers and helpful) were set up as hooks, but didn't need to be.  Those hooks were not updating when the product would be updated.